### PR TITLE
[MRG] BUG: refactor event listeners to prevent sporadically occuring trial failure

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -66,7 +66,7 @@
 	-ms-transform-origin: center left;
 	-o-transform-origin: center left;
 	transform-origin: center left;
-	transform: rotate(325deg) ;
+	transform: rotate(0deg) ;
 	display: none;
 }
 

--- a/src/js/blocksetting123.js
+++ b/src/js/blocksetting123.js
@@ -142,6 +142,7 @@ function assessPerformance(prediction, outcome) {
   } else {
     console.log('miss');
   }
+  console.log(prediction, outcome);
   return hit;
 }
 
@@ -165,6 +166,7 @@ function practice_block(timeline, jsPsych) {
     const colorStyleP = colorP[n - 1];
     var x1;
     var x2;
+    let usr_pred;
     let outcome;
     let mean;
     if (colorStyleP === colorsP[0]) {
@@ -227,6 +229,8 @@ function practice_block(timeline, jsPsych) {
         });
       },
       on_finish: function () {
+        let pred_idx = jsPsych.data.get().select('prediction').count();
+        usr_pred = jsPsych.data.get().select('prediction').values[pred_idx - 1];
         //(data)
         // psiturk.recordTrialData(data);
         // psiturk.saveData();
@@ -245,10 +249,8 @@ function practice_block(timeline, jsPsych) {
       data: { type: trial_type_label },
       on_load: function () {
         $('#shield').toggle(true);
-        const fullTime = jsPsych.data.get().select('prediction').count();
-        const shield_m = jsPsych.data.get().select('prediction').values[fullTime - 1];
-        $('#picker').css('transform', 'rotate(' + shield_m + 'deg)');
-        $('#shield').css('transform', 'rotate(' + (shield_m + 20) + 'deg) skewX(-50deg)');
+        $('#picker').css('transform', 'rotate(' + usr_pred + 'deg)');
+        $('#shield').css('transform', 'rotate(' + (usr_pred + 20) + 'deg) skewX(-50deg)');
         $('#counter').text(n_TrialPractice + 1 - n);
         $('#picker-circle').css('background-color', colorStyleP);
         $('#pickerOutcome').css('transform', 'rotate(' + outcome + 'deg)');
@@ -257,10 +259,7 @@ function practice_block(timeline, jsPsych) {
         data.outcome = outcome;
         data.mean = mean;
         data.color = colorStyleP;
-        // get most recent prediction and use it to assess performance
-        const last_trial = jsPsych.data.get().select('prediction').count();
-        const prediction = jsPsych.data.get().select('prediction').values[last_trial - 1];
-        data.score = assessPerformance(prediction, outcome);
+        data.score = assessPerformance(usr_pred, outcome);
         // psiturk.recordTrialData(data);
         // psiturk.saveData();
       },

--- a/src/js/blocksetting123.js
+++ b/src/js/blocksetting123.js
@@ -166,7 +166,7 @@ function practice_block(timeline, jsPsych) {
     const colorStyleP = colorP[n - 1];
     var x1;
     var x2;
-    let usr_pred;
+    let prediction;
     let outcome;
     let mean;
     if (colorStyleP === colorsP[0]) {
@@ -217,7 +217,7 @@ function practice_block(timeline, jsPsych) {
     }
     console.log(outcome);
 
-    var prediction = {
+    var make_prediction = {
       type: Click,
       on_load: function () {
         $('#counter').text(n_TrialPractice + 1 - n);
@@ -230,10 +230,7 @@ function practice_block(timeline, jsPsych) {
       },
       on_finish: function () {
         let pred_idx = jsPsych.data.get().select('prediction').count();
-        usr_pred = jsPsych.data.get().select('prediction').values[pred_idx - 1];
-        //(data)
-        // psiturk.recordTrialData(data);
-        // psiturk.saveData();
+        prediction = jsPsych.data.get().select('prediction').values[pred_idx - 1];
       },
     };
 
@@ -244,13 +241,13 @@ function practice_block(timeline, jsPsych) {
       },
     };
 
-    var position = {
+    var observe_outcome = {
       type: Position,
       data: { type: trial_type_label },
       on_load: function () {
         $('#shield').toggle(true);
-        $('#picker').css('transform', 'rotate(' + usr_pred + 'deg)');
-        $('#shield').css('transform', 'rotate(' + (usr_pred + 20) + 'deg) skewX(-50deg)');
+        $('#picker').css('transform', 'rotate(' + prediction + 'deg)');
+        $('#shield').css('transform', 'rotate(' + (prediction + 20) + 'deg) skewX(-50deg)');
         $('#counter').text(n_TrialPractice + 1 - n);
         $('#picker-circle').css('background-color', colorStyleP);
         $('#pickerOutcome').css('transform', 'rotate(' + outcome + 'deg)');
@@ -259,13 +256,11 @@ function practice_block(timeline, jsPsych) {
         data.outcome = outcome;
         data.mean = mean;
         data.color = colorStyleP;
-        data.score = assessPerformance(usr_pred, outcome);
-        // psiturk.recordTrialData(data);
-        // psiturk.saveData();
+        data.score = assessPerformance(prediction, outcome);
       },
     };
     var practice = {
-      timeline: [prediction, blank, position],
+      timeline: [make_prediction, blank, observe_outcome],
     };
     timeline.push(practice);
   }
@@ -290,6 +285,7 @@ function block1(timeline, jsPsych) {
     const colorStyle = color1;
     counter1++;
     var x;
+    let prediction;
     if (counter1 <= n_SamePosition + jitters[c]) {
       // counter1 = counter1;
     } else if (counter1 > n_SamePosition + jitters[c]) {
@@ -308,7 +304,7 @@ function block1(timeline, jsPsych) {
     //   console.log(mean);
     //   console.log(jitters[c]);
 
-    var prediction = {
+    var make_prediction = {
       type: Click,
       on_load: function () {
         $('#counter').text(n_TrialPerBlock + 1 - n);
@@ -320,8 +316,8 @@ function block1(timeline, jsPsych) {
         });
       },
       on_finish: function () {
-        // psiturk.recordTrialData([data]);
-        // psiturk.saveData();
+        let pred_idx = jsPsych.data.get().select('prediction').count();
+        prediction = jsPsych.data.get().select('prediction').values[pred_idx - 1];
       },
     };
 
@@ -332,15 +328,13 @@ function block1(timeline, jsPsych) {
       },
     };
 
-    var position = {
+    var observe_outcome = {
       type: Position,
       data: { type: trial_type_label },
       on_load: function () {
         $('#shield').toggle(true);
-        const fullTime = jsPsych.data.get().select('prediction').count();
-        const shield_m = jsPsych.data.get().select('prediction').values[fullTime - 1];
-        $('#picker').css('transform', 'rotate(' + shield_m + 'deg)');
-        $('#shield').css('transform', 'rotate(' + (shield_m + 20) + 'deg) skewX(-50deg)');
+        $('#picker').css('transform', 'rotate(' + prediction + 'deg)');
+        $('#shield').css('transform', 'rotate(' + (prediction + 20) + 'deg) skewX(-50deg)');
         $('#counter').text(n_TrialPerBlock + 1 - n);
         $('#picker-circle').css('background-color', colorStyle);
         $('#pickerOutcome').css('transform', 'rotate(' + outcome + 'deg)');
@@ -349,16 +343,11 @@ function block1(timeline, jsPsych) {
         data.outcome = outcome;
         data.mean = mean;
         data.color = colorStyle;
-        // get most recent prediction and use it to assess performance
-        const last_trial = jsPsych.data.get().select('prediction').count();
-        const prediction = jsPsych.data.get().select('prediction').values[last_trial - 1];
         data.score = assessPerformance(prediction, outcome);
-        // psiturk.recordTrialData([data]);
-        // psiturk.saveData();
       },
     };
     var block1 = {
-      timeline: [prediction, blank, position],
+      timeline: [make_prediction, blank, observe_outcome],
     };
     timeline.push(block1);
   }
@@ -393,6 +382,7 @@ function block2(timeline, jsPsych, sync_cp = true) {
     const colorStyle2 = color2[n - 1];
     var x1;
     var x2;
+    let prediction;
     let outcome;
     let mean;
     if (colorStyle2 === colors2[0]) {
@@ -432,7 +422,7 @@ function block2(timeline, jsPsych, sync_cp = true) {
       mean = x2;
     }
 
-    var prediction2 = {
+    var make_prediction = {
       type: Click,
       on_load: function () {
         $('#counter').text(n_TrialPerBlock + 1 - n);
@@ -444,9 +434,8 @@ function block2(timeline, jsPsych, sync_cp = true) {
         });
       },
       on_finish: function () {
-        //(data)
-        // psiturk.recordTrialData([data]);
-        // psiturk.saveData();
+        let pred_idx = jsPsych.data.get().select('prediction').count();
+        prediction = jsPsych.data.get().select('prediction').values[pred_idx - 1];
       },
     };
 
@@ -457,15 +446,13 @@ function block2(timeline, jsPsych, sync_cp = true) {
       },
     };
 
-    var position2 = {
+    var observe_outcome = {
       type: Position,
       data: { type: trial_type_label },
       on_load: function () {
         $('#shield').toggle(true);
-        const fullTime = jsPsych.data.get().select('prediction').count();
-        const shield_m = jsPsych.data.get().select('prediction').values[fullTime - 1];
-        $('#picker').css('transform', 'rotate(' + shield_m + 'deg)');
-        $('#shield').css('transform', 'rotate(' + (shield_m + 20) + 'deg) skewX(-50deg)');
+        $('#picker').css('transform', 'rotate(' + prediction + 'deg)');
+        $('#shield').css('transform', 'rotate(' + (prediction + 20) + 'deg) skewX(-50deg)');
         $('#counter').text(n_TrialPerBlock + 1 - n);
         $('#picker-circle').css('background-color', colorStyle2);
         $('#pickerOutcome').css('transform', 'rotate(' + outcome + 'deg)');
@@ -474,16 +461,11 @@ function block2(timeline, jsPsych, sync_cp = true) {
         data.outcome = outcome;
         data.mean = mean;
         data.color = colorStyle2;
-        // get most recent prediction and use it to assess performance
-        const last_trial = jsPsych.data.get().select('prediction').count();
-        const prediction = jsPsych.data.get().select('prediction').values[last_trial - 1];
         data.score = assessPerformance(prediction, outcome);
-        // psiturk.recordTrialData([data]);
-        // psiturk.saveData();
       },
     };
     var block2 = {
-      timeline: [prediction2, blank2, position2],
+      timeline: [make_prediction, blank2, observe_outcome],
     };
     timeline.push(block2);
   }
@@ -524,6 +506,7 @@ function block3(timeline, jsPsych, sync_cp = true) {
     var y1;
     var y2;
     var y3;
+    let prediction;
     let outcome;
     let mean;
     if (colorStyle3 === colors3[0]) {
@@ -583,7 +566,7 @@ function block3(timeline, jsPsych, sync_cp = true) {
       mean = y3;
     }
 
-    var prediction3 = {
+    var make_prediction = {
       type: Click,
       on_load: function () {
         $('#counter').text(n_TrialPerBlock + 1 - n);
@@ -595,8 +578,8 @@ function block3(timeline, jsPsych, sync_cp = true) {
         });
       },
       on_finish: function () {
-        // psiturk.recordTrialData([data]);
-        // psiturk.saveData();
+        let pred_idx = jsPsych.data.get().select('prediction').count();
+        prediction = jsPsych.data.get().select('prediction').values[pred_idx - 1];
       },
     };
 
@@ -607,15 +590,13 @@ function block3(timeline, jsPsych, sync_cp = true) {
       },
     };
 
-    var position3 = {
+    var observe_outcome = {
       type: Position,
       data: { type: trial_type_label },
       on_load: function () {
         $('#shield').toggle(true);
-        const fullTime = jsPsych.data.get().select('prediction').count();
-        const shield_m = jsPsych.data.get().select('prediction').values[fullTime - 1];
-        $('#picker').css('transform', 'rotate(' + shield_m + 'deg)');
-        $('#shield').css('transform', 'rotate(' + (shield_m + 20) + 'deg) skewX(-50deg)');
+        $('#picker').css('transform', 'rotate(' + prediction + 'deg)');
+        $('#shield').css('transform', 'rotate(' + (prediction + 20) + 'deg) skewX(-50deg)');
         $('#counter').text(n_TrialPerBlock + 1 - n);
         $('#picker-circle').css('background-color', colorStyle3);
         $('#pickerOutcome').css('transform', 'rotate(' + outcome + 'deg)');
@@ -624,16 +605,11 @@ function block3(timeline, jsPsych, sync_cp = true) {
         data.outcome = outcome;
         data.mean = mean;
         data.color = colorStyle3;
-        // get most recent prediction and use it to assess performance
-        const last_trial = jsPsych.data.get().select('prediction').count();
-        const prediction = jsPsych.data.get().select('prediction').values[last_trial - 1];
         data.score = assessPerformance(prediction, outcome);
-        // psiturk.recordTrialData([data]);
-        // psiturk.saveData();
       },
     };
     var block3 = {
-      timeline: [prediction3, blank3, position3],
+      timeline: [make_prediction, blank3, observe_outcome],
     };
     timeline.push(block3);
   }

--- a/src/js/prediction.js
+++ b/src/js/prediction.js
@@ -60,7 +60,7 @@ class Click {
       var circle = document.getElementById('circle'), //
         picker = document.getElementById('picker'),
         shield = document.getElementById('shield'),
-        pickerCircle = picker.firstElementChild, //picker position
+        // pickerCircle = picker.firstElementChild, //picker position
         rect = circle.getBoundingClientRect(),
         center = {
           x: rect.left + rect.width / 2,
@@ -110,33 +110,7 @@ class Click {
         return rotate(x, y) + 20;
       };
 
-      var clickTime = [];
-      // DRAGSTART
-      const mousedown = (event) => {
-        //event.preventDefault()
-        mousemove(event);
-        document.addEventListener('mousemove.drag', mousemove);
-        document.addEventListener('mouseup', mouseup);
-      };
-      // DRAG
-      const mousemove = (event) => {
-        $('#picker').toggle(true); //删掉picker
-        $('#h').toggle(true);
-        $('#v').toggle(true);
-        $('#shield').toggle(true);
-        shield.style.transform =
-          'rotate(' + shieldRotate(event.clientX, event.clientY) + 'deg) skewX(-50deg)';
-        // picker.style[transform] = 'rotate(' + rotate(event.clientX, event.clientY) + 'deg)';
-        // console.log('rotate(' + rotate(event.clientX, event.clientY) + 'deg)');
-        picker.style.transform = 'rotate(' + rotate(event.clientX, event.clientY) + 'deg)';
-
-        var getClickTime = performance.now();
-        clickTime.push(getClickTime);
-      };
-
-      // DRAGEND
-
-      function PickerData() {
+      function getPickerData() {
         var rotate = $('#picker').css('transform');
         var a = rotate.indexOf('(');
         var b = rotate.indexOf(',');
@@ -164,15 +138,31 @@ class Click {
         return pickerAngle;
       }
 
-      const mouseup = () => {
-        //(event)
-        var data = PickerData();
+      // start click
+      const mousedown = () => {
+        circle.addEventListener('mouseup', mouseup);
+      };
+
+      // end click
+      const mouseup = (event) => {
+        circle.removeEventListener('mouseup', mouseup);
+        circle.removeEventListener('mousedown', mousedown);
+
+        // update shield and picker positions
+        $('#picker').toggle(true);
         $('#h').toggle(true);
         $('#v').toggle(true);
-        document.removeEventListener('mouseup', mouseup);
-        document.removeEventListener('mousemove.drag', mousemove);
+        $('#shield').toggle(true);
+        shield.style.transform =
+          'rotate(' + shieldRotate(event.clientX, event.clientY) + 'deg) skewX(-50deg)';
+        // picker.style[transform] = 'rotate(' + rotate(event.clientX, event.clientY) + 'deg)';
+        // console.log('rotate(' + rotate(event.clientX, event.clientY) + 'deg)');
+        picker.style.transform = 'rotate(' + rotate(event.clientX, event.clientY) + 'deg)';
+
+        // get picker data and initiate end of response
+        var data = getPickerData();
         var info = {};
-        info.rt = clickTime - startTime;
+        info.rt = performance.now() - startTime;
         info.delay = startTime;
         info.prediction = data;
 
@@ -181,12 +171,7 @@ class Click {
         after_response(info);
       };
 
-      // DRAG START
-      pickerCircle.addEventListener('mousedown', mousedown);
-      pickerCircle.addEventListener('mousemove.drag', mousemove);
-      document.addEventListener('mousemove.drag', mousemove);
-
-      // ENABLE STARTING THE DRAG IN THE BLACK CIRCLE
+      // ENABLE STARTING THE CLICK IN THE BLACK CIRCLE
       circle.addEventListener('mousedown', function (event) {
         if (event.target == this) mousedown(event);
       });

--- a/src/js/prediction.js
+++ b/src/js/prediction.js
@@ -125,10 +125,10 @@ class Click {
         $('#v').toggle(true);
         $('#shield').toggle(true);
         shield.style.transform =
-          'rotate(' + shieldRotate(event.pageX, event.pageY) + 'deg) skewX(-50deg)';
-        // picker.style[transform] = 'rotate(' + rotate(event.pageX, event.pageY) + 'deg)';
-        // console.log('rotate(' + rotate(event.pageX, event.pageY) + 'deg)');
-        picker.style.transform = 'rotate(' + rotate(event.pageX, event.pageY) + 'deg)';
+          'rotate(' + shieldRotate(event.clientX, event.clientY) + 'deg) skewX(-50deg)';
+        // picker.style[transform] = 'rotate(' + rotate(event.clientX, event.clientY) + 'deg)';
+        // console.log('rotate(' + rotate(event.clientX, event.clientY) + 'deg)');
+        picker.style.transform = 'rotate(' + rotate(event.clientX, event.clientY) + 'deg)';
 
         var getClickTime = performance.now();
         clickTime.push(getClickTime);

--- a/src/js/prediction.js
+++ b/src/js/prediction.js
@@ -54,13 +54,11 @@ class Click {
       new_html += '</div>';
       new_html += '<div id="counter"></div>';
 
-      //new_html += '<div "class=circle-in"></div>';
       display_element.innerHTML = new_html;
 
       var circle = document.getElementById('circle'), //
         picker = document.getElementById('picker'),
         shield = document.getElementById('shield'),
-        // pickerCircle = picker.firstElementChild, //picker position
         rect = circle.getBoundingClientRect(),
         center = {
           x: rect.left + rect.width / 2,

--- a/src/js/prediction.js
+++ b/src/js/prediction.js
@@ -67,113 +67,38 @@ class Click {
           y: rect.top + rect.height / 2,
         };
 
-      // var transform = function() {
-      //   ///
+      const click_callback = (event) => {
+        // clear listener
+        circle.removeEventListener('click', click_callback);
 
-      //   var prefs = ['t', 'WebkitT', 'MozT', 'msT', 'OT'],
-      //     style = document.documentElement.style,
-      //     p;
-
-      //   for (var i = 0, len = prefs.length; i < len; i++) {
-      //     if ((p = prefs[i] + 'ransform') in style) return p; //  + 'ransform' ？？
-      //   }
-      //   console.log('p')
-
-      //   alert('your browser doesnt support css transforms!');
-      // };
-
-      const rotate = (x, y) => {
-        //x,y to deg？
-        var deltaX = x - center.x,
-          deltaY = y - center.y,
-          // The atan2 method returns a numeric value between -pi and pi representing the angle theta of an (x,y) point.
-          // This is the counterclockwise angle, measured in radians, between the positive X axis, and the point (x,y).
-          // Note that the arguments to this function pass the y-coordinate first and the x-coordinate second.
-          // atan2 is passed separate x and y arguments, and atan is passed the ratio of those two arguments.
-          // * from Mozilla's MDN
-
-          // Basically you give it an [y, x] difference of two points and it give you back an angle
-          // The 0 point of the angle is left (the initial position of the picker is also left)
-
-          angle = (Math.atan2(deltaY, deltaX) * 180) / Math.PI;
-
-        // Math.atan2(deltaY, deltaX) => [-PI +PI]
-        // We must convert it to deg so...
-        // / Math.PI => [-1 +1]
-        // * 180 => [-180 +180]
-
-        return angle;
-      };
-
-      const shieldRotate = (x, y) => {
-        // 红色阴影的度数？？为什么不是上下两个呢
-        return rotate(x, y) + 20;
-      };
-
-      function getPickerData() {
-        var rotate = $('#picker').css('transform');
-        var a = rotate.indexOf('(');
-        var b = rotate.indexOf(',');
-        var c = rotate.indexOf(',', 20);
-        var pickerCos = rotate.slice(a + 1, b);
-        var pickerSin = rotate.slice(b + 1, c);
-        var pickerTan = pickerSin / pickerCos;
-        var pickerAngle = (Math.atan(pickerTan) / Math.PI) * 180;
-
-        // console.log(a + 1, b)
-        // console.log(pickerCos)
-        // console.log(pickerSin)
-        // console.log(pickerTan)
-        // console.log(pickerAngle)
-
-        if (pickerCos < 0 && pickerSin < 0) {
-          pickerAngle = pickerAngle + 180;
-        } else if (pickerCos < 0 && pickerSin > 0) {
-          pickerAngle = pickerAngle + 180;
-        } else if (pickerCos > 0 && pickerSin < 0) {
-          pickerAngle = pickerAngle + 360;
-        } else if (pickerCos === 1 && pickerSin === 0) {
-          pickerAngle = 0;
-        }
-        return pickerAngle;
-      }
-
-      // start click
-      const mousedown = () => {
-        circle.addEventListener('mouseup', mouseup);
-      };
-
-      // end click
-      const mouseup = (event) => {
-        circle.removeEventListener('mouseup', mouseup);
-        circle.removeEventListener('mousedown', mousedown);
+        // get prediction position angle
+        let x = event.clientX - center.x;
+        let y = event.clientY - center.y;
+        // NB: y increases going downward in the client window, so a positive
+        // angle reflects a clockwise deviation relative to the positive x-axis
+        let angle = Math.atan2(y, x) * (180 / Math.PI);
+        // convert domain from [-180, 180]->[0, 360]
+        angle = Math.mod(angle, 360)
 
         // update shield and picker positions
         $('#picker').toggle(true);
         $('#h').toggle(true);
         $('#v').toggle(true);
         $('#shield').toggle(true);
-        shield.style.transform =
-          'rotate(' + shieldRotate(event.clientX, event.clientY) + 'deg) skewX(-50deg)';
-        // picker.style[transform] = 'rotate(' + rotate(event.clientX, event.clientY) + 'deg)';
-        // console.log('rotate(' + rotate(event.clientX, event.clientY) + 'deg)');
-        picker.style.transform = 'rotate(' + rotate(event.clientX, event.clientY) + 'deg)';
+        shield.style.transform = 'rotate(' + (angle + 20) + 'deg) skewX(-50deg)';
+        picker.style.transform = 'rotate(' + angle + 'deg)';
 
         // get picker data and initiate end of response
-        var data = getPickerData();
         var info = {};
         info.rt = performance.now() - startTime;
         info.delay = startTime;
-        info.prediction = data;
-
-        // console.log(data);
-
+        info.prediction = angle;
         after_response(info);
       };
 
       // ENABLE STARTING THE CLICK IN THE BLACK CIRCLE
-      circle.addEventListener('mousedown', function (event) {
-        if (event.target == this) mousedown(event);
+      circle.addEventListener('click', function (event) {
+        if (event.target == this) click_callback(event);
       });
     };
 


### PR DESCRIPTION
The goal here is to fix a sporadically occurring bug where user predictions (mouse click location events) aren't getting registered properly. We hope that this can be fixed by simplifying which event listeners are created and then properly disposing of them once they're unneeded:

- [x] access event coordinates using `event.clientX` instead of `event.pageX`,
- [x] use only ~mousedown and mouseup~* click events since we don't care about mouse positioning during the down-phase of the click,
- [x] click position is logged on ~mouseup~* up-phase of mouse click, after which the event listeners for this trial are removed,
- [x] event listeners are restricted to the `circle` display element instead of entire `document`,
- [x] finally, the logic for angle calculation occurs first in the callback and is then passed to html/css elements rather than doing round-trip writing+reading, greatly simplifying codebase.

\* edited 05/15